### PR TITLE
Update references after move wmurphyrd -> c-frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Super Hands
 
-[![Build Status](https://travis-ci.com/wmurphyrd/aframe-super-hands-component.svg?branch=master)](https://travis-ci.com/wmurphyrd/aframe-super-hands-component)
+[![Build Status](https://travis-ci.com/c-frame/aframe-super-hands-component.svg?branch=master)](https://travis-ci.com/c-frame/aframe-super-hands-component)
 [![npm Dowloads](https://img.shields.io/npm/dt/super-hands.svg?style=flat-square)](https://www.npmjs.com/package/super-hands)
 [![npm Version](http://img.shields.io/npm/v/super-hands.svg?style=flat-square)](https://www.npmjs.com/package/super-hands)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
@@ -107,12 +107,12 @@ require('super-hands');
 
 ## Examples
 
-The [examples page](https://wmurphyrd.github.io/aframe-super-hands-component/examples/) showcases a variety of configurations and use cases for `super-hands`.
+The [examples page](https://c-frame.github.io/aframe-super-hands-component/examples/) showcases a variety of configurations and use cases for `super-hands`.
 
 | Example Scene | Description | Target VR Devices |
 | --- | --- | --- |
-| [Hand controllers with physics](https://wmurphyrd.github.io/aframe-super-hands-component/examples/#physics) | Grab, stretch, and drag-drop cubes with simulated physical behavior in roomscale VR | Vive, Rift, Windows MR |
-| [Gaze and laser pointer controls without physics](https://wmurphyrd.github.io/aframe-super-hands-component/examples/#mouse) | Showcase fallback controls used for simpler VR devices and fallback interactivity without physics simulation | Desktop, mobile, cardboard, Gear VR, Daydream, Vive, Rift, Windows MR |
+| [Hand controllers with physics](https://c-frame.github.io/aframe-super-hands-component/examples/#physics) | Grab, stretch, and drag-drop cubes with simulated physical behavior in roomscale VR | Vive, Rift, Windows MR |
+| [Gaze and laser pointer controls without physics](https://c-frame.github.io/aframe-super-hands-component/examples/#mouse) | Showcase fallback controls used for simpler VR devices and fallback interactivity without physics simulation | Desktop, mobile, cardboard, Gear VR, Daydream, Vive, Rift, Windows MR |
 
 ## News
 
@@ -226,7 +226,7 @@ In addition to the A-Frame style gesture events,
 interactions to be emitted by the target entities. This allows the use of these
 common Global Event Handler properties on entities to add reaction directly
 in the HTML. View the
-[related example](https://wmurphyrd.github.io/aframe-super-hands-component/examples/#events)
+[related example](https://c-frame.github.io/aframe-super-hands-component/examples/#events)
 to see this in use.
 
 | entity HTML attribute | conditions | event.relatedTarget |

--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -77,7 +77,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/index.html
+++ b/examples/index.html
@@ -63,7 +63,7 @@
   <body>
     <h1>A-Frame Super Hands Component</h1>
     <p>This is the examples page for the
-      <a href="http://github.com/wmurphyrd/aframe-super-hands-component">
+      <a href="http://github.com/c-frame/aframe-super-hands-component">
         super-hands A-Frame component package
       </a>
       for super-easy hand controller interactivity in A-Frame WebVR experiences.
@@ -125,7 +125,7 @@ super-hands="colliderEvent: raycaster-intersection;
   <script>
   (async function() {
     var converter = new showdown.Converter();
-    var response = await fetch('https://raw.githubusercontent.com/wmurphyrd/aframe-super-hands-component/master/getting-started.md');
+    var response = await fetch('https://raw.githubusercontent.com/c-frame/aframe-super-hands-component/master/getting-started.md');
     var md = await response.text()
     var html = converter.makeHtml(md);
     document.querySelector('#dynamic-guide-here').innerHTML = html;
@@ -145,7 +145,7 @@ super-hands="colliderEvent: raycaster-intersection;
     </ul>
   -->
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/mouse/index-mouse.html
+++ b/examples/mouse/index-mouse.html
@@ -48,7 +48,7 @@
       </a-link>
     </a-scene>
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/mouse/index.html
+++ b/examples/mouse/index.html
@@ -61,7 +61,7 @@
       </a-link>
     </a-scene>
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/physics/index-laser.html
+++ b/examples/physics/index-laser.html
@@ -74,7 +74,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/physics/index-mouse.html
+++ b/examples/physics/index-mouse.html
@@ -88,7 +88,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/physics/index.html
+++ b/examples/physics/index.html
@@ -93,7 +93,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/portals.html
+++ b/examples/portals.html
@@ -62,7 +62,7 @@
       </a-link>
     </a-scene>
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/sticky/index.html
+++ b/examples/sticky/index.html
@@ -60,7 +60,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/examples/super-basic/index.html
+++ b/examples/super-basic/index.html
@@ -2,7 +2,7 @@
   <title>Most Basic Super-Hands Example</title>
   <script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/donmccurdy/aframe-extras@v6.1.1/dist/aframe-extras.misc.min.js"></script>
-  <script src="https://rawgit.com/wmurphyrd/aframe-super-hands-component/master/dist/super-hands.js"></script>
+  <script src="https://rawgit.com/c-frame/aframe-super-hands-component/master/dist/super-hands.js"></script>
 </head>
 
 <body>

--- a/machinima_tests/scenes/hands-laser.html
+++ b/machinima_tests/scenes/hands-laser.html
@@ -36,7 +36,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/machinima_tests/scenes/progressive-laser.html
+++ b/machinima_tests/scenes/progressive-laser.html
@@ -28,7 +28,7 @@
     </a-scene>
 
     <!-- GitHub Corner. -->
-    <a href="https://github.com/wmurphyrd/aframe-super-hands-component" class="github-corner">
+    <a href="https://github.com/c-frame/aframe-super-hands-component" class="github-corner">
       <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
       </svg>

--- a/news.md
+++ b/news.md
@@ -28,7 +28,7 @@ v3.0.0
     package.
     I intend to refactor it and release it in another library, but you can
     still use the last version by including
-    [its source file](https://github.com/wmurphyrd/aframe-super-hands-component/blob/dc1a601b7fa9d606a05ec2d3500f8f141c65c20c/misc_components/progressive-controls.js) in your project.
+    [its source file](https://github.com/c-frame/aframe-super-hands-component/blob/dc1a601b7fa9d606a05ec2d3500f8f141c65c20c/misc_components/progressive-controls.js) in your project.
 * Smarter raycasting support: chooses nearest intersected entity first,
   reordering stack as distances change (\* if the raycaster in use updates
   intersection objects' distances)
@@ -87,7 +87,7 @@ v2.0.0
 * Button mapping for reaction components: each reaction component now has
   `startButtons` and `endButtons` schema properties to specify acceptable
   buttons. This allows different entities to react to different buttons.
-  [For example](https://wmurphyrd.github.io/aframe-super-hands-component/examples/#sticky)
+  [For example](https://c-frame.github.io/aframe-super-hands-component/examples/#sticky)
   `a-locomotor`'s `grabbable` can be set to respond to different
   buttons than other `grabbable` entities so that
   grabbing entities and locomotion are separate gestures for the user.
@@ -103,7 +103,7 @@ v1.1.0
 * Compatibility with desktop mouse control via A-Frame `cursor` component
   * Added new schema property `colliderEventProperty` to configure
     where in the `event.details` to look for the collision target
-  * Requires some configuration of schema properties, see new example: [Mouse Controls](https://wmurphyrd.github.io/aframe-super-hands-component/examples/#mouse)
+  * Requires some configuration of schema properties, see new example: [Mouse Controls](https://c-frame.github.io/aframe-super-hands-component/examples/#mouse)
 * Select examples now have `avatar-replayer` to preview actions without needing
   VR equipment
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wmurphyrd/aframe-super-hands-component.git"
+    "url": "git+https://github.com/c-frame/aframe-super-hands-component.git"
   },
   "keywords": [
     "aframe",
@@ -39,9 +39,9 @@
   "author": "William Murphy william@datatitian.com",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wmurphyrd/aframe-super-hands-component/issues"
+    "url": "https://github.com/c-frame/aframe-super-hands-component/issues"
   },
-  "homepage": "https://github.com/wmurphyrd/aframe-super-hands-component#readme",
+  "homepage": "https://github.com/c-frame/aframe-super-hands-component#readme",
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@c-frame/aframe-physics-system": "^4.1.0",


### PR DESCRIPTION
I spotted that the link to the examples in the REAMDE is now out of date.  And there's a bunch of similar links that need updating.

Changes all pretty straightforward apart from one...

Build status points to a travis-ci URL:

https://travis-ci.com/wmurphyrd/aframe-super-hands-component.svg?branch=master

The old URL now reports "cancelled", while the new one reports "unknown"

Guess we need to set up Travis CI to point to the c-frame repo?  Is that something you can do @wmurphyrd ?
Alternatively, we could move the CI to GH actions?


